### PR TITLE
add config variable for graph uri (infra.cat integration)

### DIFF
--- a/__tests__/facebook-messenger-client.js
+++ b/__tests__/facebook-messenger-client.js
@@ -354,13 +354,13 @@ test('creates valid request when grah_uri changes (infra.cat integration)', () =
     user: '1'
   }
 
-  var newURI = 'https://meow.infra.cat/v2.6/me/messages';
+  var newURI = 'https://meow.infra.cat';
   var client = new FacebookMessengerClient({
     graph_uri: newURI,
   })(bot)
   var request = client.startTyping(session)
 
-  expect(request.uri).toEqual(newURI)
+  expect(request.uri).toEqual(newURI+'/v2.6/me/messages')
   expect(request.method).toEqual('POST')
   expect(request.json).toEqual({
     recipient: {

--- a/__tests__/facebook-messenger-client.js
+++ b/__tests__/facebook-messenger-client.js
@@ -347,3 +347,25 @@ test('creates valid request when triggering typing indicator', () => {
     sender_action: 'typing_on'
   })
 })
+
+test('creates valid request when grah_uri changes (infra.cat integration)', () => {
+
+  var session = {
+    user: '1'
+  }
+
+  var newURI = 'https://meow.infra.cat/v2.6/me/messages';
+  var client = new FacebookMessengerClient({
+    graph_uri: newURI,
+  })(bot)
+  var request = client.startTyping(session)
+
+  expect(request.uri).toEqual(newURI)
+  expect(request.method).toEqual('POST')
+  expect(request.json).toEqual({
+    recipient: {
+      id: '1'
+    },
+    sender_action: 'typing_on'
+  })
+})

--- a/lib/facebook-messenger-client.js
+++ b/lib/facebook-messenger-client.js
@@ -6,7 +6,7 @@ function FacebookMessengerClient(config) {
     var defaults = {
       verify_token: process.env.MESSENGER_VERIFY_TOKEN,
       access_token: process.env.MESSENGER_ACCESS_TOKEN,
-      graph_uri: 'https://graph.facebook.com/v2.6/me/messages',
+      graph_uri: 'https://graph.facebook.com',
     }
 
     this.bot = bot
@@ -113,7 +113,7 @@ FacebookMessengerClient.prototype.send = function(session, text, attachment) {
   }
 
   return request({
-    uri: this.config.graph_uri,
+    uri: this.config.graph_uri+'/v2.6/me/messages',
     qs: { access_token: this.config.access_token },
     method: 'POST',
     json: messageData
@@ -137,7 +137,7 @@ FacebookMessengerClient.prototype.startTyping = function(session) {
   }
 
   return request({
-    uri: this.config.graph_uri,
+    uri: this.config.graph_uri+'/v2.6/me/messages',
     qs: { access_token: this.config.access_token },
     method: 'POST',
     json: messageData

--- a/lib/facebook-messenger-client.js
+++ b/lib/facebook-messenger-client.js
@@ -5,7 +5,8 @@ function FacebookMessengerClient(config) {
   return function(bot) {
     var defaults = {
       verify_token: process.env.MESSENGER_VERIFY_TOKEN,
-      access_token: process.env.MESSENGER_ACCESS_TOKEN
+      access_token: process.env.MESSENGER_ACCESS_TOKEN,
+      graph_uri: 'https://graph.facebook.com/v2.6/me/messages',
     }
 
     this.bot = bot
@@ -112,7 +113,7 @@ FacebookMessengerClient.prototype.send = function(session, text, attachment) {
   }
 
   return request({
-    uri: 'https://graph.facebook.com/v2.6/me/messages',
+    uri: this.config.graph_uri,
     qs: { access_token: this.config.access_token },
     method: 'POST',
     json: messageData
@@ -136,7 +137,7 @@ FacebookMessengerClient.prototype.startTyping = function(session) {
   }
 
   return request({
-    uri: 'https://graph.facebook.com/v2.6/me/messages',
+    uri: this.config.graph_uri,
     qs: { access_token: this.config.access_token },
     method: 'POST',
     json: messageData


### PR DESCRIPTION
Allow integration with infra.cat by changing `graph_uri` config variable in messenger client

example of use: 
````
bot.use(new Bottr.FacebookMessengerClient({
    graph_uri: 'https://meow.infra.cat',
  }))
````

ref: #33 