### PR TITLE
Added meaningful error messaging for fb integration

### DIFF
--- a/lib/clients/facebook-messenger-client.js
+++ b/lib/clients/facebook-messenger-client.js
@@ -122,7 +122,7 @@ FacebookMessengerClient.prototype.send = function(session, text, attachment) {
     if (!error && response.statusCode == 200) {
       console.log('Successfully sent message.')
     } else {
-      console.error('Unable to send message.')
+      console.error('Unable to send message. Please verify your access_token.')
     }
   })
 }
@@ -145,7 +145,7 @@ FacebookMessengerClient.prototype.startTyping = function(session) {
     if (!error && response.statusCode == 200) {
       console.log('Successfully started typing indicator.')
     } else {
-      console.error('Unable to start typing indicator.')
+      console.error('Unable to start typing indicator. Please verify your access_token ')
     }
   })
 }


### PR DESCRIPTION
The errors logged in case of Messenger communications prints out errors in the console accessed by `heroku logs -t`.

Add pointers to the actual question, as to why the app failed.