### PR TITLE
Broken link update

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
       <div class="content">
         <h1 class="text-white">The World's Simplest Bot Framework</h1>
         <div class="intro">
-          <a class="button btn-main" href="https://bottr.co/docs/install">Get Started</a>
+          <a class="button btn-main" href="https://github.com/Bottr-js/Bottr/wiki/Creating-a-new-project">Get Started</a>
           <a class="button" href="https://github.com/Bottr-js/Bottr">Contribute</a>
         </div>
         <div class="message two-small">


### PR DESCRIPTION
As per issue #61, `Get Started` link URL is replaced with `https://github.com/Bottr-js/Bottr/wiki/Creating-a-new-project`