### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -4,7 +4,7 @@ const Express = require('express');
 const ResponseMiddleware = require('./response-middleware');
 const fs = require('fs');
 const request = require('request');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const cors = require('cors');
 const Topic = require('./topic');
 

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "body-parser": "^1.15.2",
     "cors": "^2.8.1",
     "express": "^4.14.0",
-    "node-uuid": "^1.4.7",
     "queue": "^4.0.0",
     "request": "^2.74.0",
     "socket.io": "^1.4.8",
     "twilio": "^2.9.2",
-    "twit": "^2.2.4"
+    "twit": "^2.2.4",
+    "uuid": "^3.0.0"
   },
   "scripts": {
     "lint": "eslint __mocks__ __tests__ lib index.js",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.